### PR TITLE
Fix incorrect log file name

### DIFF
--- a/helm/microgateway/logging/init.sh
+++ b/helm/microgateway/logging/init.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 touch /home/ballerina/logs/microgw.log
-/ballerina/runtime/bin/ballerina run --config /home/ballerina/conf/micro-gw.conf $PROJECT.balx 2>&1 | tee -a /home/ballerina/logs/microgw.logs
+/ballerina/runtime/bin/ballerina run --config /home/ballerina/conf/micro-gw.conf $PROJECT.balx 2>&1 | tee -a /home/ballerina/logs/microgw.log


### PR DESCRIPTION
## Purpose
Fix incorrect log file name from "/home/ballerina/logs/microgw.logs" to "/home/ballerina/logs/microgw.log"