### PR TITLE
[1.1.x] Router Heap Dump Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,12 @@ For detailed information on the tasks carried out during this release, please se
 - Readiness and liveness probe endpoints (refer to [issue](https://github.com/wso2/kubernetes-microgateway/issues/38)).
 
 For detailed information on the tasks carried out during this release, please see the GitHub milestone [v1.1.0.2](https://github.com/wso2/kubernetes-microgateway/milestone/6)
+
+## [v1.1.0.3] - 2022-07-11
+
+### Added
+
+- Mount empty dir to write Router heap/CPU profile data (refer to [issue](https://github.com/wso2/kubernetes-microgateway/issues/45)).
+- Override Docker registry in component level (refer to [issue](https://github.com/wso2/kubernetes-microgateway/issues/46)).
+
+For detailed information on the tasks carried out during this release, please see the GitHub milestone [v1.1.0.3](https://github.com/wso2/kubernetes-microgateway/milestone/8)

--- a/helm/choreo-connect/Chart.yaml
+++ b/helm/choreo-connect/Chart.yaml
@@ -16,6 +16,6 @@ apiVersion: v2
 name: choreo-connect
 description: A Helm chart for the deployment of Choreo Connect
 type: application
-version: 1.1.0-2
+version: 1.1.0-3
 appVersion: "1.1.0"
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/helm/choreo-connect/README.md
+++ b/helm/choreo-connect/README.md
@@ -470,6 +470,8 @@ Gateway runtime (enforcer + router) deployment configurations
 | `wso2.deployment.gatewayRuntime.router.containerSecurityContext`            | Security context of the the adapter container                                             | allowPrivilegeEscalation:&nbsp;false</br>readOnlyRootFilesystem:&nbsp;true</br>capabilities:</br>&nbsp;&nbsp;drop:</br>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;all</br>|
 | `wso2.deployment.gatewayRuntime.router.security.backendCaCerts`             | Trusted backend certs in PEM format (Refer [Configure Certificates](#configure-certificates)) | Default envoy CA Certs  |
 | `wso2.deployment.gatewayRuntime.router.security.keystore`                   | Private key and cert in PEM format (Refer [Configure Certificates](#configure-certificates))  | Default Certs           |
+| `wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountEmptyDir`     | Mount an K8s empty dir to write Heap/CPU profile data                                     | false                       |
+| `wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountPath`         | Path to mount the empty dir to write Heap/CPU profile data                                | "/var/log/envoy"            |
 
 ## Kubernetes Specific Configurations
 

--- a/helm/choreo-connect/README.md
+++ b/helm/choreo-connect/README.md
@@ -49,13 +49,13 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
   Helm version 2
   
   ```
-  helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE>
+  helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE>
   ```
   
   Helm version 3
 
   ```
-  helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE> --create-namespace
+  helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE> --create-namespace
   ```
 
 The above steps will deploy the Choreo Connect using WSO2 product Docker images available at DockerHub.
@@ -66,7 +66,7 @@ please provide your WSO2 Subscription credentials via input values (using `--set
 Please see the following example.
 
 ```
- helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE> \
+ helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE> \
   --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> \
   --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
@@ -125,14 +125,14 @@ hence if you have not specified `wso2.deployment.mode` "Standalone" deployment m
 Helm v2
 
 ```
-helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE> \
+helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE> \
   --set wso2.deployment.mode=STANDALONE
 ```
 
 Helm v3
 
 ```
-helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE> --create-namespace
+helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE> --create-namespace
   --set wso2.deployment.mode=STANDALONE
 ```
 
@@ -157,7 +157,7 @@ Helm version 2
 helm install --name apim-as-cp wso2/am-single-node --version 4.1.0-1 --namespace apim \
   --set wso2.deployment.am.ingress.gateway.hostname=gw.wso2.com \
   --set wso2.deployment.am.ingress.gateway.enabled=false \
-  --set-file wso2.deployment.am.config."deployment\.toml"=https://raw.githubusercontent.com/wso2/kubernetes-microgateway/v1.1.0.2/resources/controlplane-deployment.toml
+  --set-file wso2.deployment.am.config."deployment\.toml"=https://raw.githubusercontent.com/wso2/kubernetes-microgateway/v1.1.0.3/resources/controlplane-deployment.toml
 ```
 
 Helm version 3
@@ -166,7 +166,7 @@ Helm version 3
 helm install apim-as-cp wso2/am-single-node --version 4.1.0-1 --namespace apim --create-namespace \
   --set wso2.deployment.am.ingress.gateway.hostname=gw.wso2.com \
   --set wso2.deployment.am.ingress.gateway.enabled=false \
-  --set-file wso2.deployment.am.config."deployment\.toml"=https://raw.githubusercontent.com/wso2/kubernetes-microgateway/v1.1.0.2/resources/controlplane-deployment.toml
+  --set-file wso2.deployment.am.config."deployment\.toml"=https://raw.githubusercontent.com/wso2/kubernetes-microgateway/v1.1.0.3/resources/controlplane-deployment.toml
 ```
 
 NOTE: If you do not have sufficient resources you can adjust them setting following values when installing the chart.
@@ -206,7 +206,7 @@ The following example shows how to deploy Choreo Connect with "WSO2 API Manager 
 Helm v2
 
 ```
-helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE> \
+helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE> \
   --set wso2.deployment.mode=APIM_AS_CP \
   --set wso2.apim.controlPlane.hostName=am.wso2.com \
   --set wso2.apim.controlPlane.serviceName=wso2am-single-node-am-service.apim
@@ -215,7 +215,7 @@ helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --names
 Helm v3
 
 ```
-helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE> --create-namespace \
+helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE> --create-namespace \
   --set wso2.deployment.mode=APIM_AS_CP \
   --set wso2.apim.controlPlane.hostName=am.wso2.com \
   --set wso2.apim.controlPlane.serviceName=wso2am-single-node-am-service.apim
@@ -230,7 +230,7 @@ The following example shows how to enable Analytics with the helm charts.
 Helm v2
 
 ```
-helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE> \
+helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE> \
   --set wso2.choreoAnalytics.enabled=true \
   --set wso2.choreoAnalytics.endpoint=<CHOREO_ANALYTICS_ENDPOINT> \
   --set wso2.choreoAnalytics.onpremKey=<ONPREM_KEY>
@@ -239,7 +239,7 @@ helm install --name <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --names
 Helm v3
 
 ```
-helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-2 --namespace <NAMESPACE> --create-namespace \
+helm install <RELEASE_NAME> wso2/choreo-connect --version 1.1.0-3 --namespace <NAMESPACE> --create-namespace \
   --set wso2.choreoAnalytics.enabled=true \
   --set wso2.choreoAnalytics.endpoint=<CHOREO_ANALYTICS_ENDPOINT> \
   --set wso2.choreoAnalytics.onpremKey=<ONPREM_KEY>

--- a/helm/choreo-connect/README.md
+++ b/helm/choreo-connect/README.md
@@ -368,6 +368,7 @@ If you do not have active WSO2 subscription do not change the parameters `wso2.d
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
+| `wso2.deployment.adapter.dockerRegistry`                                    | Docker registry. If this value is not empty, this overrides the value in `wso2.deployment.dockerRegistry` | -           |
 | `wso2.deployment.adapter.imageName`                                         | Image name for adapter                                                                    | "choreo-connect-adapter"    |
 | `wso2.deployment.adapter.imageTag`                                          | Image tag for adapter                                                                     | "1.1.0"                     |
 | `wso2.deployment.adapter.imagePullPolicy`                                   | Image pull policy of the container                                                        | "IfNotPresent"              |
@@ -383,7 +384,7 @@ If you do not have active WSO2 subscription do not change the parameters `wso2.d
 | `wso2.deployment.adapter.affinity`                                          | Affinity for adapter pods assignment                                                      | -                           |
 | `wso2.deployment.adapter.nodeSelector`                                      | Node labels for adapter pods assignment                                                   | -                           |
 | `wso2.deployment.adapter.tolerations`                                       | Tolerations for adapter pods assignment                                                   | -                           |
-| `wso2.deployment.adapter.podSecurityContext`                               | Security context of the the adapter pod                                                    | runAsUser:&nbsp;10500</br>runAsGroup:&nbsp;10500 |
+| `wso2.deployment.adapter.podSecurityContext`                                | Security context of the the adapter pod                                                   | runAsUser:&nbsp;10500</br>runAsGroup:&nbsp;10500 |
 | `wso2.deployment.adapter.containerSecurityContext`                          | Security context of the the adapter container                                             | allowPrivilegeEscalation:&nbsp;false</br>readOnlyRootFilesystem:&nbsp;true</br>capabilities:</br>&nbsp;&nbsp;drop:</br>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;all</br>|
 | `wso2.deployment.adapter.livenessProbe.initialDelaySeconds`                 | Number of seconds after the container has started before liveness probes are initiated    | 10                          |
 | `wso2.deployment.adapter.livenessProbe.periodSeconds`                       | How often (in seconds) to perform the probe                                               | 30                          |
@@ -421,6 +422,7 @@ Gateway runtime (enforcer + router) deployment configurations
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
+| `wso2.deployment.gatewayRuntime.enforcer.dockerRegistry`                    | Docker registry. If this value is not empty, this overrides the value in `wso2.deployment.dockerRegistry` | -           |
 | `wso2.deployment.gatewayRuntime.enforcer.imageName`                         | Image name for enforcer                                                                   | "choreo-connect-enforcer"   |
 | `wso2.deployment.gatewayRuntime.enforcer.imageTag`                          | Image tag for enforcer                                                                    | "1.1.0"                     |
 | `wso2.deployment.gatewayRuntime.enforcer.imagePullPolicy`                   | Image pull policy of the container                                                        | "IfNotPresent"              |
@@ -449,6 +451,7 @@ Gateway runtime (enforcer + router) deployment configurations
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
+| `wso2.deployment.gatewayRuntime.router.dockerRegistry`                      | Docker registry. If this value is not empty, this overrides the value in `wso2.deployment.dockerRegistry` | -           |
 | `wso2.deployment.gatewayRuntime.router.imageName`                           | Image name for enforcer                                                                   | "choreo-connect-router"     |
 | `wso2.deployment.gatewayRuntime.router.imageTag`                            | Image tag for enforcer                                                                    | "1.1.0"                     |
 | `wso2.deployment.gatewayRuntime.router.imagePullPolicy`                     | Image pull policy of the container                                                        | "IfNotPresent"              |

--- a/helm/choreo-connect/templates/_helpers.tpl
+++ b/helm/choreo-connect/templates/_helpers.tpl
@@ -85,13 +85,14 @@ Subscriptions secret name.
 Docker image name.
 */}}
 {{- define "image" }}
+{{- $componentLevelDockerRegistry := .deployment.dockerRegistry }}
 {{- $imageName := .deployment.imageName }}
 {{- $imageTag := .deployment.imageTag | default "" }}
 {{- if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") -}}
-{{- $dockerRegistry := .Values.wso2.deployment.dockerRegistry | default "wso2" }}
+{{- $dockerRegistry := $componentLevelDockerRegistry | default .Values.wso2.deployment.dockerRegistry | default "wso2" }}
 image: {{ $dockerRegistry }}/{{ $imageName }}{{- if not (eq $imageTag "") }}{{- printf ":%s" $imageTag -}}{{- end }}
 {{- else }}
-{{- $dockerRegistry := .Values.wso2.deployment.dockerRegistry | default "docker.wso2.com" }}
+{{- $dockerRegistry := $componentLevelDockerRegistry | default .Values.wso2.deployment.dockerRegistry | default "docker.wso2.com" }}
 {{- $parts := len (split "." $imageTag) }}
 {{- if and (eq $parts 3) (eq $dockerRegistry "docker.wso2.com") }}
 image: {{ $dockerRegistry }}/{{ $imageName }}{{- if not (eq $imageTag "") }}:{{ $imageTag }}.0{{- end }}

--- a/helm/choreo-connect/templates/gateway-runtime-deployment.yaml
+++ b/helm/choreo-connect/templates/gateway-runtime-deployment.yaml
@@ -62,7 +62,7 @@ spec:
       {{- end }}
       containers:
         - name: choreo-connect-enforcer
-          image: {{- include "image" (dict "Values" .Values "deployment" .Values.wso2.deployment.gatewayRuntime.enforcer) | indent 10 }}
+          {{- include "image" (dict "Values" .Values "deployment" .Values.wso2.deployment.gatewayRuntime.enforcer) | indent 10 }}
           imagePullPolicy: {{ .Values.wso2.deployment.gatewayRuntime.enforcer.imagePullPolicy }}
           volumeMounts:
           {{- if not .Values.wso2.deployment.gatewayRuntime.enforcer.security.truststore }}
@@ -184,7 +184,7 @@ spec:
             initialDelaySeconds: {{ .Values.wso2.deployment.gatewayRuntime.enforcer.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.gatewayRuntime.enforcer.livenessProbe.periodSeconds }}
         - name: choreo-connect-router
-          image: {{- include "image" (dict "Values" .Values "deployment" .Values.wso2.deployment.gatewayRuntime.router) | indent 10 }}
+          {{- include "image" (dict "Values" .Values "deployment" .Values.wso2.deployment.gatewayRuntime.router) | indent 10 }}
           imagePullPolicy: {{ .Values.wso2.deployment.gatewayRuntime.router.imagePullPolicy }}
           volumeMounts:
             - mountPath:  /home/wso2/security/keystore/mg.key
@@ -201,7 +201,7 @@ spec:
               readOnly: true
               subPath: {{- .Values.wso2.deployment.gatewayRuntime.router.security.backendCaCerts.subPath | quote }}
             {{- end }}
-            {{- if Values.wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountEmptyDir }}
+            {{- if .Values.wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountEmptyDir }}
             - mountPath: {{ .Values.wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountPath }}
               name: router-heap-profile-data
             {{- end }}
@@ -343,7 +343,7 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
-        {{- if Values.wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountEmptyDir }}
+        {{- if .Values.wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountEmptyDir }}
         - name: router-heap-profile-data
           emptyDir: {}
         {{- end }}

--- a/helm/choreo-connect/templates/gateway-runtime-deployment.yaml
+++ b/helm/choreo-connect/templates/gateway-runtime-deployment.yaml
@@ -201,6 +201,10 @@ spec:
               readOnly: true
               subPath: {{- .Values.wso2.deployment.gatewayRuntime.router.security.backendCaCerts.subPath | quote }}
             {{- end }}
+            {{- if Values.wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountEmptyDir }}
+            - mountPath: {{ .Values.wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountPath }}
+              name: router-heap-profile-data
+            {{- end }}
             - mountPath: /home/wso2/security/truststore/adapter-ca-cert.pem
               name: adapter-keystore-cert
               readOnly: true
@@ -337,6 +341,10 @@ spec:
                   name: {{ .configMapName }}
             {{- end }}
         {{- else }}
+          emptyDir: {}
+        {{- end }}
+        {{- if Values.wso2.deployment.gatewayRuntime.router.debug.heapProfile.mountEmptyDir }}
+        - name: router-heap-profile-data
           emptyDir: {}
         {{- end }}
         - name: router-keystore-key

--- a/helm/choreo-connect/values.yaml
+++ b/helm/choreo-connect/values.yaml
@@ -62,6 +62,8 @@ wso2:
     imagePullSecrets: []
 
     adapter:
+      # Docker registry. If this value is not empty, this overrides the value in 'wso2.deployment.dockerRegistry'
+      dockerRegistry: ""
       # Image name for adapter
       imageName: "choreo-connect-adapter"
       # Image tag for adapter
@@ -235,6 +237,8 @@ wso2:
         runAsGroup: 10500
       
       enforcer:
+        # Docker registry. If this value is not empty, this overrides the value in 'wso2.deployment.dockerRegistry'
+        dockerRegistry: ""
         # Image name for enforcer
         imageName: "choreo-connect-enforcer"
         # Image tag for enforcer
@@ -350,6 +354,8 @@ wso2:
         log4j2Properties: ""
 
       router:
+        # Docker registry. If this value is not empty, this overrides the value in 'wso2.deployment.dockerRegistry'
+        dockerRegistry: ""
         # Image name for router
         imageName: "choreo-connect-router"
         # Image tag for router

--- a/helm/choreo-connect/values.yaml
+++ b/helm/choreo-connect/values.yaml
@@ -429,6 +429,14 @@ wso2:
           #     secretName: "router-keystore"
           #     subPath: "tls.crt"
           keystore: {} # using default certs, if not defined.
+        
+        debug:
+          # Store heap profile data for analyzing memory leaks
+          heapProfile:
+            # Mount an K8s empty dir to write profile data
+            mountEmptyDir: false
+            # Path to mount the empty dir
+            mountPath: /var/log/envoy
           
 kubernetes:
   # Service account configurations


### PR DESCRIPTION
## Purpose
$subject

fix https://github.com/wso2/kubernetes-microgateway/issues/45
fix https://github.com/wso2/kubernetes-microgateway/issues/46
Related to https://github.com/wso2/product-microgateway/issues/2997

Mount empty dir to write Router heap/CPU profile data

```yaml
debug:
  # Store heap profile data for analyzing memory leaks
  heapProfile:
    # Mount an K8s empty dir to write profile data
    mountEmptyDir: false
    # Path to mount the empty dir
    mountPath: /var/log/envoy
```

Override Docker registry in component level

```yaml
router:
    # Docker registry. If this value is not empty, this overrides the value in 'wso2.deployment.dockerRegistry'
    dockerRegistry: ""
    # Image name for router
    imageName: "choreo-connect-router"
    # Image tag for router
    imageTag: "1.1.0"
    # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
    imagePullPolicy: IfNotPresent
```
